### PR TITLE
feat: upgrade to tokio-0.2 and futures 0.3 (std::futures)

### DIFF
--- a/.license_template
+++ b/.license_template
@@ -1,4 +1,5 @@
 // Copyright (c) {\d+} Jason White
+// Copyright (c) {\d+} Mike Lubinets
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "github-app"
 version = "0.1.0"
-authors = ["Jason White <rust@jasonwhite.io>"]
+authors = ["Jason White <rust@jasonwhite.io>, Mike Lubinets <me@mkl.dev>"]
 edition = "2018"
 description = """
 A Rust library for making GitHub Apps and bots.
@@ -18,11 +18,11 @@ chrono = { version = "0.4", features = ["serde"] }
 crypto-mac = "0.7"
 derive_more = "0.14"
 env_logger = "0.6"
-futures = "0.1"
+futures = { version = "0.3", features = ["compat"] }
 hex = "0.3"
 hmac = "0.7"
 humantime = "1"
-hyper = "0.12"
+hyper = "0.13"
 log = "0.4"
 serde = "1"
 serde_json = "1"
@@ -31,7 +31,7 @@ envy = "0.4"
 reqwest = { version = "0.9", default-features = false, features = ["rustls-tls"] }
 
 [dev-dependencies]
-tokio = "0.1"
+tokio = { version = "0.2", features = ["rt-core", "macros"] }
 pretty_env_logger = "0.3"
 structopt = "0.2"
 nom_pem = "4"

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
 Copyright (c) 2019 Jason White
+Copyright (c) 2019 Mike Lubinets
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in


### PR DESCRIPTION
This PR upgrades the library to modern Rust `async-await`, and this is a breaking change.

Additionally to that, there are a few Error `From`-conversions added, to make error-handling a bit smoother with the `?-try` operator.